### PR TITLE
Add Tag column

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,333 +17,333 @@ All creators under this section must have published something in 2022.
 ### Australia 
 <img src="4x3/au.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Christian Findlay | [Blog](https://christianfindlay.com)
-| Les Jackson | [YouTube](https://www.youtube.com/c/binarythistle)
-| Rahul Nath | [YouTube](https://www.youtube.com/c/RahulNath)
-| Rahul Rai | [Blog](https://thecloudblog.net)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Christian Findlay | [Blog](https://christianfindlay.com) |  |
+| Les Jackson | [YouTube](https://www.youtube.com/c/binarythistle) |  |
+| Rahul Nath | [YouTube](https://www.youtube.com/c/RahulNath) |  |
+| Rahul Rai | [Blog](https://thecloudblog.net) |  |
 
 ### Austria 
 <img src="4x3/at.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Christian Nagel | [Blog](https://csharp.christiannagel.com), [Twitter](https://twitter.com/ChristianNagel)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Christian Nagel | [Blog](https://csharp.christiannagel.com), [Twitter](https://twitter.com/ChristianNagel) |  |
 
 
 ### Belgium
 
 <img src="4x3/be.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Maarten Balliauw | [Blog](https://blog.maartenballiauw.be/)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Maarten Balliauw | [Blog](https://blog.maartenballiauw.be/) |  |
 
 ### Canada
 <img src="4x3/ca.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Derek Comartin | [YouTube](https://www.youtube.com/channel/UC3RKA4vunFAfrfxiJhPEplw)
-| Frank Liu | [YouTube](https://www.youtube.com/c/FrankLiuSoftware/)
-| Richard Campbell | [Podcast](https://www.dotnetrocks.com/)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Derek Comartin | [YouTube](https://www.youtube.com/channel/UC3RKA4vunFAfrfxiJhPEplw) |  |
+| Frank Liu | [YouTube](https://www.youtube.com/c/FrankLiuSoftware/) |  |
+| Richard Campbell | [Podcast](https://www.dotnetrocks.com/) |  |
 
 
 ### Dominican Republic 
 <img src="4x3/do.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Steven Checo | [Blog](https://checox.com)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Steven Checo | [Blog](https://checox.com) |  |
 
 ### Egypt
 <img src="4x3/eg.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Shady Nagy | [Blog](https://shadynagy.com/)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Shady Nagy | [Blog](https://shadynagy.com/) |  |
 
 ### France
 <img src="4x3/fr.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Alexis Chân GRIDEL | [Blog](https://agdl.dev) 
-| Daniel Lawson | [Twitter Threads](https://github.com/danylaws/my-twitter-threads)|
-| Martin Finkel | [Blog](https://mfkl.github.io)|
-| Laurent Egbakou | [Blog](https://lioncoding.com)|
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Alexis Chân GRIDEL | [Blog](https://agdl.dev) |  |
+| Daniel Lawson | [Twitter Threads](https://github.com/danylaws/my-twitter-threads) |  |
+| Martin Finkel | [Blog](https://mfkl.github.io) |  |
+| Laurent Egbakou | [Blog](https://lioncoding.com) |  |
 
 
 ### Germany
 <img src="4x3/de.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Holger Schwichtenberg | [Twitter](https://twitter.com/DOTNETDOKTOR)
-| Thomas Claudius Huber | [Pluralsight](https://app.pluralsight.com/profile/author/thomas-huber)
-| Tim Cadenbach | [Blog](https://www.tcdev.de/blog)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Holger Schwichtenberg | [Twitter](https://twitter.com/DOTNETDOKTOR) |  |
+| Thomas Claudius Huber | [Pluralsight](https://app.pluralsight.com/profile/author/thomas-huber) |  |
+| Tim Cadenbach | [Blog](https://www.tcdev.de/blog) |  |
 
 ### India
 <img src="4x3/in.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Abdul Rahman | [Site](https://www.ilovedotnet.org)
-| Anto Subash | [YouTube](https://www.youtube.com/c/AntoSubash), [Blog](https://blog.antosubash.com)
-| Anurag Sinha  | [Blog](https://techncodetools.com/blog/)
-| Bhrugen Patel | [YouTube](https://www.youtube.com/user/bhrugen1990), [Courses](https://www.dotnetmastery.com/)
-| Mukesh Murugan | [Blog](https://codewithmukesh.com/blog)
-| Nouman Rahman  | [Blog](https://programmingfire.com)
-| Saineshwar Bageri | [Blog](https://tutexchange.com)
-| Shailendra Chauhan | [YouTube](https://www.youtube.com/channel/UCuYuSB7JzDslrwwh8EM-4JA)
-| Shivprasad Koirala | [YouTube](https://www.youtube.com/c/questpondvideos)
-| Shreyas Jejurkar  | [Blog](https://shreyasjejurkar.com)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Abdul Rahman | [Site](https://www.ilovedotnet.org) |  |
+| Anto Subash | [YouTube](https://www.youtube.com/c/AntoSubash), [Blog](https://blog.antosubash.com) |  |
+| Anurag Sinha  | [Blog](https://techncodetools.com/blog/) |  |
+| Bhrugen Patel | [YouTube](https://www.youtube.com/user/bhrugen1990), [Courses](https://www.dotnetmastery.com/) |  |
+| Mukesh Murugan | [Blog](https://codewithmukesh.com/blog) |  |
+| Nouman Rahman  | [Blog](https://programmingfire.com) |  |
+| Saineshwar Bageri | [Blog](https://tutexchange.com) |  |
+| Shailendra Chauhan | [YouTube](https://www.youtube.com/channel/UCuYuSB7JzDslrwwh8EM-4JA) |  |
+| Shivprasad Koirala | [YouTube](https://www.youtube.com/c/questpondvideos) |  |
+| Shreyas Jejurkar  | [Blog](https://shreyasjejurkar.com) |  |
 
 
 ### Israel
 <img src="4x3/il.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Amichai Mantinband | [YouTube](https://www.youtube.com/c/AmichaiMantinband/), [Twitter](https://twitter.com/amantinband/), [LinkedIn](https://www.linkedin.com/in/amantinband/)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Amichai Mantinband | [YouTube](https://www.youtube.com/c/AmichaiMantinband/), [Twitter](https://twitter.com/amantinband/), [LinkedIn](https://www.linkedin.com/in/amantinband/) |  |
 
 
 ### Italy
 <img src="4x3/it.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Davide Bellone | [Blog](https://www.code4it.dev)
-| Fabio Ramoni | [Twitter](https://twitter.com/developer_fabio), [Twitter Threads (GitHub)](https://github.com/FabioDeveloper92/developer_fabio_twitter_threads)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Davide Bellone | [Blog](https://www.code4it.dev) |  |
+| Fabio Ramoni | [Twitter](https://twitter.com/developer_fabio), [Twitter Threads (GitHub)](https://github.com/FabioDeveloper92/developer_fabio_twitter_threads) |  |
 
 
 ### Japan
 <img src="4x3/jp.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Andrew KeepCoding | [YouTube](https://www.youtube.com/c/AndrewKeepCoding/), [Twitter](https://twitter.com/AndrewKeepCodin)
-| Ted Andersen | [YouTube](https://www.youtube.com/c/TedsTech)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Andrew KeepCoding | [YouTube](https://www.youtube.com/c/AndrewKeepCoding/), [Twitter](https://twitter.com/AndrewKeepCodin) |  |
+| Ted Andersen | [YouTube](https://www.youtube.com/c/TedsTech) |  |
 
 ### Jamaica
 <img src="4x3/jm.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Trevoir Williams | [YouTube](https://www.youtube.com/c/trevoirwilliams)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Trevoir Williams | [YouTube](https://www.youtube.com/c/trevoirwilliams) |  |
 
 
 ### Lebanon
 <img src="4x3/lb.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Ahmad Mozaffar | [YouTube](https://www.youtube.com/channel/UCRs-PO48PbbS0l7bBhbu5CA)
-| Hasan Aboul | [Blog](https://learnwithhasan.com)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Ahmad Mozaffar | [YouTube](https://www.youtube.com/channel/UCRs-PO48PbbS0l7bBhbu5CA) |  |
+| Hasan Aboul | [Blog](https://learnwithhasan.com) |  |
 
 
 ### Malawi
 <img src="4x3/mw.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Simuzeche Kaluwa  | [YouTube](https://www.youtube.com/channel/UCQw4zDb735eezImafcyYlWg)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Simuzeche Kaluwa  | [YouTube](https://www.youtube.com/channel/UCQw4zDb735eezImafcyYlWg) |  |
 
 
 ### Mauritius
 <img src="4x3/mu.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Patrick Smacchia | [Blog](https://blog.ndepend.com)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Patrick Smacchia | [Blog](https://blog.ndepend.com) |  |
 
 ### Netherlands
 <img src="4x3/nl.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Gerald Versluis | [YouTube](https://www.youtube.com/c/GeraldVersluis)
-| Henrique Siebert Domareski | [Blog](https://henriquesd.medium.com), [LinkedIn](https://www.linkedin.com/in/henriquesd)
-| Marc Duiker | [YouTube](https://www.youtube.com/c/marcduiker-serverless), [Blog](https://blog.marcduiker.nl)
-| Max Hamulyák | [Blog](https://kaylumah.nl/blog)
-| Roland Guijt | [Pluralsight](https://app.pluralsight.com/profile/author/roland-guijt)
-| Fanie Reynders | [Twitch](https://twitch.tv/faniereynders), [YouTube](https://YouTube.com/faniereynders)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Gerald Versluis | [YouTube](https://www.youtube.com/c/GeraldVersluis) |  |
+| Henrique Siebert Domareski | [Blog](https://henriquesd.medium.com), [LinkedIn](https://www.linkedin.com/in/henriquesd) |  |
+| Marc Duiker | [YouTube](https://www.youtube.com/c/marcduiker-serverless), [Blog](https://blog.marcduiker.nl) |  |
+| Max Hamulyák | [Blog](https://kaylumah.nl/blog) |  |
+| Roland Guijt | [Pluralsight](https://app.pluralsight.com/profile/author/roland-guijt) |  |
+| Fanie Reynders | [Twitch](https://twitch.tv/faniereynders), [YouTube](https://YouTube.com/faniereynders) |  |
 
 
 ### New Zealand
 <img src="4x3/nz.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Jakub Chodounský | [Newsletter (csharpdigest.net)](https://csharpdigest.net/), [Twitter](https://twitter.com/jakubgarfield)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Jakub Chodounský | [Newsletter (csharpdigest.net)](https://csharpdigest.net/), [Twitter](https://twitter.com/jakubgarfield) |  |
 
 ### Norway
 <img src="4x3/no.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Kris Devochko | [Blog](https://kristhecodingunicorn.com/post/)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Kris Devochko | [Blog](https://kristhecodingunicorn.com/post/) |  |
 
 
 
 ### Poland
 <img src="4x3/pl.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Szymon Kulec  | [Blog](https://blog.scooletz.com/)
-| Oleg Kyrylchuk | [Blog](https://blog.okyrylchuk.dev/)
-| Oskar Dudycz  | [Blog](https://event-driven.io/en/)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Szymon Kulec  | [Blog](https://blog.scooletz.com/) |  |
+| Oleg Kyrylchuk | [Blog](https://blog.okyrylchuk.dev/) |  |
+| Oskar Dudycz  | [Blog](https://event-driven.io/en/) |  |
 
 
 ### Portugal
 <img src="4x3/pt.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Guilherme Ferreira  | [Blog](https://gsferreira.com), [YouTube](https://www.youtube.com/user/guilhermeasferreira)
-| João Antunes  | [YouTube](https://www.youtube.com/c/CodingMilitia)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Guilherme Ferreira  | [Blog](https://gsferreira.com), [YouTube](https://www.youtube.com/user/guilhermeasferreira) |  |
+| João Antunes  | [YouTube](https://www.youtube.com/c/CodingMilitia) |  |
 
 
 ### Romania
 <img src="4x3/ro.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-|  Dan Patrascu-Baba  | [YouTube](https://www.youtube.com/channel/UCyTPru-1gZ7-4qblcKM0TiQ)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+|  Dan Patrascu-Baba  | [YouTube](https://www.youtube.com/channel/UCyTPru-1gZ7-4qblcKM0TiQ) |  |
 
 
 ### Serbia
 <img src="4x3/rs.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Marinko Spasojevic | [Blog](https://code-maze.com/)
-| Milan Milanović | [LinkedIn](https://www.linkedin.com/in/milanmilanovic/), [Blog](https://milan.milanovic.org/post/), [Twitter](https://twitter.com/milan_milanovic)
-| Milan Jovanović | [LinkedIn](https://www.linkedin.com/in/milan-jovanovic), [YouTube](https://www.youtube.com/c/MilanJovanovicTech), [Twitter](https://twitter.com/mjovanovictech)
-| Zoran Horvat | [Twitter](https://twitter.com/zoranh75), [Blog](https://codinghelmet.com/articles), [YouTube](https://www.youtube.com/c/zh-code)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Marinko Spasojevic | [Blog](https://code-maze.com/) |  |
+| Milan Milanović | [LinkedIn](https://www.linkedin.com/in/milanmilanovic/), [Blog](https://milan.milanovic.org/post/), [Twitter](https://twitter.com/milan_milanovic) |  |
+| Milan Jovanović | [LinkedIn](https://www.linkedin.com/in/milan-jovanovic), [YouTube](https://www.youtube.com/c/MilanJovanovicTech), [Twitter](https://twitter.com/mjovanovictech) |  |
+| Zoran Horvat | [Twitter](https://twitter.com/zoranh75), [Blog](https://codinghelmet.com/articles), [YouTube](https://www.youtube.com/c/zh-code) |  |
 
 ### Switzerland
 <img src="4x3/ch.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Claudio Bernasconi | [YouTube](https://youtube.com/claudiobernasconi)
-| Damien Bowden  | [Blog](https://damienbod.com)
-| Emanuele Bartolesi | [Blog](https://dev.to/kasuken)
-| Matthias Güntert | [Blog](https://www.azureblue.io/), [LinkedIn](https://www.linkedin.com/in/matthiasguentert/)
-| Jürgen Gutsch | [Blog](https://asp.net-hacker.rocks)
-| Steven Giesel |  [Blog](https://steven-giesel.com)
-| Wolfgang Ofner | [Blog](https://programmingwithwolfgang.com/)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Claudio Bernasconi | [YouTube](https://youtube.com/claudiobernasconi) |  |
+| Damien Bowden  | [Blog](https://damienbod.com) |  |
+| Emanuele Bartolesi | [Blog](https://dev.to/kasuken) |  |
+| Matthias Güntert | [Blog](https://www.azureblue.io/), [LinkedIn](https://www.linkedin.com/in/matthiasguentert/) |  |
+| Jürgen Gutsch | [Blog](https://asp.net-hacker.rocks) |  |
+| Steven Giesel |  [Blog](https://steven-giesel.com) |  |
+| Wolfgang Ofner | [Blog](https://programmingwithwolfgang.com/) |  |
 
 
 ### Turkey
 <img src="4x3/tr.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Sabit Kondakçı | [LinkedIn](https://www.linkedin.com/in/sabit-kondak%C3%A7%C4%B1/) 
-| Engincan Veske | [Blog](https://engincanv.github.io/)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Sabit Kondakçı | [LinkedIn](https://www.linkedin.com/in/sabit-kondak%C3%A7%C4%B1/) |  |
+| Engincan Veske | [Blog](https://engincanv.github.io/) |  |
 
 ### Ukraine
 <img src="4x3/ua.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Oleksii Nikiforov | [Blog](https://nikiforovall.github.io), [Twitter](https://twitter.com/nikiforovall)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Oleksii Nikiforov | [Blog](https://nikiforovall.github.io), [Twitter](https://twitter.com/nikiforovall) |  |
 
 
 ### United Kingdom
 <img src="4x3/gb.svg" height="35">
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Andrea Angella | [YouTube](https://www.youtube.com/c/AndreaAngella)
-| Andrew Lock | [Blog](https://andrewlock.net/)
-| Anton Wieslander | [YouTube](https://www.youtube.com/c/RawCoding)
-| Dan Clarke | [Podcast](https://unhandledexceptionpodcast.com/)
-| Dave Murray | [Blog](https://blog.taranissoftware.com/)
-| David Grace | [Blog](https://www.roundthecode.com/), [YouTube](https://www.youtube.com/roundthecode)
-| Gavin Lon | [YouTube](https://www.youtube.com/c/GavinLon/)
-| Jamie Maguire | [Blog](https://jamiemaguire.net/)
-| Jamie Taylor | [Podcast](https://dotnetcore.show)
-| John Reilly | [Blog](https://blog.johnnyreilly.com), [Twitter](https://twitter.com/johnny_reilly)
-| Jon Hilton | [Blog](https://jonhilton.net/), [Courses](https://practicaldotnet.io)
-| Jon P Smith | [Blog](https://www.thereformedprogrammer.net)
-| Jon Skeet | [Blog](https://codeblog.jonskeet.uk/)
-| Layla Porter | [Twitch](https://www.twitch.tv/laylacodesit)
-| Mark Heath | [Pluralsight](https://app.pluralsight.com/profile/author/mark-heath), [Blog](https://markheath.net)
-| Mohamad Lawand | [YouTube](https://www.youtube.com/c/MohamadLawand)
-| Nick Chapsas | [YouTube](https://www.youtube.com/c/Elfocrash)
-| Paul Michaels | [Site](https://pmichaels.net)
-| Peter Morris | [Site](https://blazor-university.com)
-| Scott Wlaschin | [Site](https://fsharpforfunandprofit.com)
-| Steve Gordon | [Pluralsight](https://app.pluralsight.com/profile/author/steve-gordon)
-| Stuart Blackler | [YouTube](https://www.youtube.com/c/CodeWithStu/videos), [LinkedIn](https://www.linkedin.com/in/im5tu/), [Blog](https://im5tu.io/article/)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Andrea Angella | [YouTube](https://www.youtube.com/c/AndreaAngella) |  |
+| Andrew Lock | [Blog](https://andrewlock.net/) |  |
+| Anton Wieslander | [YouTube](https://www.youtube.com/c/RawCoding) |  |
+| Dan Clarke | [Podcast](https://unhandledexceptionpodcast.com/) |  |
+| Dave Murray | [Blog](https://blog.taranissoftware.com/) |  |
+| David Grace | [Blog](https://www.roundthecode.com/), [YouTube](https://www.youtube.com/roundthecode) |  |
+| Gavin Lon | [YouTube](https://www.youtube.com/c/GavinLon/) |  |
+| Jamie Maguire | [Blog](https://jamiemaguire.net/) |  |
+| Jamie Taylor | [Podcast](https://dotnetcore.show) |  |
+| John Reilly | [Blog](https://blog.johnnyreilly.com), [Twitter](https://twitter.com/johnny_reilly) |  |
+| Jon Hilton | [Blog](https://jonhilton.net/), [Courses](https://practicaldotnet.io) |  |
+| Jon P Smith | [Blog](https://www.thereformedprogrammer.net) |  |
+| Jon Skeet | [Blog](https://codeblog.jonskeet.uk/) |  |
+| Layla Porter | [Twitch](https://www.twitch.tv/laylacodesit) |  |
+| Mark Heath | [Pluralsight](https://app.pluralsight.com/profile/author/mark-heath), [Blog](https://markheath.net) |  |
+| Mohamad Lawand | [YouTube](https://www.youtube.com/c/MohamadLawand) |  |
+| Nick Chapsas | [YouTube](https://www.youtube.com/c/Elfocrash) |  |
+| Paul Michaels | [Site](https://pmichaels.net) |  |
+| Peter Morris | [Site](https://blazor-university.com) |  |
+| Scott Wlaschin | [Site](https://fsharpforfunandprofit.com) |  |
+| Steve Gordon | [Pluralsight](https://app.pluralsight.com/profile/author/steve-gordon) |  |
+| Stuart Blackler | [YouTube](https://www.youtube.com/c/CodeWithStu/videos), [LinkedIn](https://www.linkedin.com/in/im5tu/), [Blog](https://im5tu.io/article/) |  |
 
 ### USA
 <img src="4x3/us.svg" height="35">
 
-  | Name  | Main Channel |
-  | ------------- | ------------- |
-  | Bryan Hogan | [Podcast](https://nodogmapodcast.bryanhogan.net/)
-  | Chris Patterson | [YouTube](https://www.youtube.com/c/PhatBoyG)
-  | Carl Franklin | [Podcast](https://www.dotnetrocks.com/), [BlazorTrain YouTube](https://www.youtube.com/playlist?list=PL8h4jt35t1wjvwFnvcB2LlYL4jLRzRmoz)
-  | David McCarter | [Blog](https://dotNetTips.com), [Live Show](https://www.c-sharpcorner.com/live/rockin-the-code-world-with-dotnetdave)
-  | Hassan Rezk Habib | [LinkedIn](https://www.linkedin.com/in/hassanrezkhabib/recent-activity/shares/), [linktree](https://linktr.ee/hassanrezkhabib)
-  | John Savill | [YouTube](https://www.youtube.com/c/NTFAQGuy)
-  | James Montemagno | [YouTube](https://www.youtube.com/c/JamesMontemagno), [Podcast](https://www.mergeconflict.fm/)
-  | Jeffrey T. Fritz | [YouTube](https://www.youtube.com/c/csharpfritz/), [Twitch](https://www.twitch.tv/csharpfritz), [linktree](https://linktr.ee/csharpfritz)
-  | Jimmy Bogard | [Blog](https://jimmybogard.com/)
-  | Julie Lerman | [Twitter](https://twitter.com/julielerman)
-  | Kendra Havens | [Twitter](https://twitter.com/gotheap)
-  | Kevin Bost | [YouTube](https://www.youtube.com/c/KevinBost)
-  | Khalid Abuhakmeh | [Blog](https://khalidabuhakmeh.com/)
-  | Niels Swimberghe | [Blog](https://swimburger.net)
-  | Richard Campbell | [Podcast](https://www.dotnetrocks.com)
-  | Rockford Lhotka | [Blog](https://blog.lhotka.net), [Twitter](https://www.twitter.com/rockylhotka)
-  | Saar Shen | [Site](https://www.codewithsaar.net/), [YouTube](https://youtube.com/c/CodewithSaar)
-  | Scott Hanselman | [YouTube](https://www.youtube.com/channel/UCL-fHOdarou-CR2XUmK48Og), [Podcast](https://www.hanselminutes.com/)
-  | Sean Killeen | [Blog](https://seankilleen.com/)
-  | Shawn Wildermuth | [Pluralsight](https://app.pluralsight.com/profile/author/shawn-wildermuth)
-  | SingletonSean | [YouTube](https://www.youtube.com/c/SingletonSean)
-  | Steve Ardalis Smith  | [Blog](https://ardalis.com/blog)  
-  | Tim Corey | [YouTube](https://youtube.com/user/IAmTimCorey), [Podcast](https://iamtimcorey.com/p/podcast)
-  | Wes Doyle | [YouTube](https://youtube.com/c/WesDoyle)
+  | Name  | Main Channel | Tags |
+  | ------------- | ------------- | ------------- |
+  | Bryan Hogan | [Podcast](https://nodogmapodcast.bryanhogan.net/) |  |
+  | Chris Patterson | [YouTube](https://www.youtube.com/c/PhatBoyG) |  |
+  | Carl Franklin | [Podcast](https://www.dotnetrocks.com/), [BlazorTrain YouTube](https://www.youtube.com/playlist?list=PL8h4jt35t1wjvwFnvcB2LlYL4jLRzRmoz) |  |
+  | David McCarter | [Blog](https://dotNetTips.com), [Live Show](https://www.c-sharpcorner.com/live/rockin-the-code-world-with-dotnetdave) |  |
+  | Hassan Rezk Habib | [LinkedIn](https://www.linkedin.com/in/hassanrezkhabib/recent-activity/shares/), [linktree](https://linktr.ee/hassanrezkhabib) |  |
+  | John Savill | [YouTube](https://www.youtube.com/c/NTFAQGuy) |  |
+  | James Montemagno | [YouTube](https://www.youtube.com/c/JamesMontemagno), [Podcast](https://www.mergeconflict.fm/) |  |
+  | Jeffrey T. Fritz | [YouTube](https://www.youtube.com/c/csharpfritz/), [Twitch](https://www.twitch.tv/csharpfritz), [linktree](https://linktr.ee/csharpfritz) |  |
+  | Jimmy Bogard | [Blog](https://jimmybogard.com/) |  |
+  | Julie Lerman | [Twitter](https://twitter.com/julielerman) |  |
+  | Kendra Havens | [Twitter](https://twitter.com/gotheap) |  |
+  | Kevin Bost | [YouTube](https://www.youtube.com/c/KevinBost) |  |
+  | Khalid Abuhakmeh | [Blog](https://khalidabuhakmeh.com/) |  |
+  | Niels Swimberghe | [Blog](https://swimburger.net) |  |
+  | Richard Campbell | [Podcast](https://www.dotnetrocks.com) |  |
+  | Rockford Lhotka | [Blog](https://blog.lhotka.net), [Twitter](https://www.twitter.com/rockylhotka) |  |
+  | Saar Shen | [Site](https://www.codewithsaar.net/), [YouTube](https://youtube.com/c/CodewithSaar) |  |
+  | Scott Hanselman | [YouTube](https://www.youtube.com/channel/UCL-fHOdarou-CR2XUmK48Og), [Podcast](https://www.hanselminutes.com/) |  |
+  | Sean Killeen | [Blog](https://seankilleen.com/) |  |
+  | Shawn Wildermuth | [Pluralsight](https://app.pluralsight.com/profile/author/shawn-wildermuth) |  |
+  | SingletonSean | [YouTube](https://www.youtube.com/c/SingletonSean) |  |
+  | Steve Ardalis Smith  | [Blog](https://ardalis.com/blog) |  |
+  | Tim Corey | [YouTube](https://youtube.com/user/IAmTimCorey), [Podcast](https://iamtimcorey.com/p/podcast) |  |
+  | Wes Doyle | [YouTube](https://youtube.com/c/WesDoyle) |  |
 
 ### Official MSFT / .NET Foundation content resources / Xamarin
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| .NET Microsoft Channels | [Blog](https://devblogs.microsoft.com/dotnet), [YouTube](https://www.youtube.com/c/dotNET), [Documentation](https://docs.microsoft.com/en-us/dotnet)
-| .NET Foundation | [YouTube](https://www.youtube.com/c/NETFoundation)
-| Microsoft Visual Studio | [YouTube](https://www.youtube.com/c/visualstudio),  [Blog](https://devblogs.microsoft.com/visualstudio/)
-| Xamarin Developers | [YouTube](https://www.youtube.com/c/XamarinDevelopers)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| .NET Microsoft Channels | [Blog](https://devblogs.microsoft.com/dotnet), [YouTube](https://www.youtube.com/c/dotNET), [Documentation](https://docs.microsoft.com/en-us/dotnet) |  |
+| .NET Foundation | [YouTube](https://www.youtube.com/c/NETFoundation) |  |
+| Microsoft Visual Studio | [YouTube](https://www.youtube.com/c/visualstudio),  [Blog](https://devblogs.microsoft.com/visualstudio/) |  |
+| Xamarin Developers | [YouTube](https://www.youtube.com/c/XamarinDevelopers) |  |
 
 ### Multi-Creator Channels / Creator Name Unkown
 
-| Name  | Main Channel |
-| ------------- | ------------- |
-| 6 Figure Developer Podcast | [Podcast](https://6figuredev.com/category/podcast/)
-| Code Maze | [Blog](https://www.code-maze.com)
-| Coding Blocks| [Podcast](https://www.codingblocks.net/)
-| Curious Drive | [YouTube](https://www.youtube.com/c/CuriousDrive)
-| C# Corner | [Blog](https://www.c-sharpcorner.com/)
-| DevMentors | [YouTube](https://www.youtube.com/c/DevMentors), [Site](https://devmentors.io)
-| Dotnetos | [Blog](https://dotnetos.org/blog), [YouTube](https://youtube.com/c/Dotnetos)
-| DotNet Core Central | [YouTube](https://www.youtube.com/c/DotNetCoreCentral)
-| ExceptionNotFound | [Blog](https://www.exceptionnotfound.net)
-| tutorials.EU | [YouTube](https://www.youtube.com/c/tutorialsEU), [Courses](https://tutorials.eu/)
-| Kudvenkat/Pragim | [YouTube](https://www.youtube.com/c/Csharp-video-tutorialsBlogspot)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| 6 Figure Developer Podcast | [Podcast](https://6figuredev.com/category/podcast/) |  |
+| Code Maze | [Blog](https://www.code-maze.com) |  |
+| Coding Blocks| [Podcast](https://www.codingblocks.net/) |  |
+| Curious Drive | [YouTube](https://www.youtube.com/c/CuriousDrive) |  |
+| C# Corner | [Blog](https://www.c-sharpcorner.com/) |  |
+| DevMentors | [YouTube](https://www.youtube.com/c/DevMentors), [Site](https://devmentors.io) |  |
+| Dotnetos | [Blog](https://dotnetos.org/blog), [YouTube](https://youtube.com/c/Dotnetos) |  |
+| DotNet Core Central | [YouTube](https://www.youtube.com/c/DotNetCoreCentral) |  |
+| ExceptionNotFound | [Blog](https://www.exceptionnotfound.net) |  |
+| tutorials.EU | [YouTube](https://www.youtube.com/c/tutorialsEU), [Courses](https://tutorials.eu/) |  |
+| Kudvenkat/Pragim | [YouTube](https://www.youtube.com/c/Csharp-video-tutorialsBlogspot) |  |
 
 ### Aggregator Sites
-| Name  | Main Channel |
-| ------------- | ------------- |
-| Discover.NET | [Site](https://discoverdot.net)
-| .NET Ketchup | [Site](https://dotnetketchup.com)
-| The Morning Brew by Chris Alcock, UK | [Site](https://blog.cwa.me.uk/)
-| The Morning Dew by Alvin Ashcraft, USA | [Site](https://www.alvinashcraft.com/)
+| Name  | Main Channel | Tags |
+| ------------- | ------------- | ------------- |
+| Discover.NET | [Site](https://discoverdot.net) |  |
+| .NET Ketchup | [Site](https://dotnetketchup.com) |  |
+| The Morning Brew by Chris Alcock, UK | [Site](https://blog.cwa.me.uk/) |  |
+| The Morning Dew by Alvin Ashcraft, USA | [Site](https://www.alvinashcraft.com/) |  |
 
 ## 🪴 Contribute
 * No matter if huge or a small following: The quality matters. 
@@ -353,4 +353,3 @@ All creators under this section must have published something in 2022.
 * Special thanks [Shreyas Jejurkar](https://twitter.com/ShreyasJejurkar) for sharing a lot of awesome YouTube channels that I didn't know: [List of YouTube channels for .NET C# developers](https://shreyasjejurkar.com/?p=728)
 * Special thanks to the [dotnet Twitter Community](https://twitter.com/i/communities/1488624124817666051) for suggesting creators
 * Flags copied from: https://flagicons.lipis.dev / https://github.com/lipis/flag-icons
-


### PR DESCRIPTION
Contributors can add tags (genres/categories) to content creators. This will make easier to find content creators without clicking the links.

For example:
- General .NET
- Windows Desktop
- Azure
- ASP.NET
- etc...