### PR TITLE
remove discoverdot.net it is no longer active and domain points to so…

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,6 @@ Poornima Nayar | [Blog](https://poornimanayar.co.uk/), [Twitter](https://twitter
 ### 🐙 Aggregator Sites
 | Name  | Channels | Tags |
 | --- | --- | --- |
-| Discover.NET | [Site](https://discoverdot.net) | .NET, Aggregator Site |
 | .NET Ketchup | [Site](https://dotnetketchup.com) | .NET, Aggregator Site |
 | The Morning Brew by Chris Alcock, UK | [Site](https://blog.cwa.me.uk/) | .NET, Aggregator Site  |
 | The Morning Dew by Alvin Ashcraft, USA | [Site](https://www.alvinashcraft.com/) | .NET, Aggregator Site |


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change removes `Discover.NET` from the list of aggregator sites.

![image](https://github.com/user-attachments/assets/58e058c7-acbb-475a-bb40-f8f952208156)
